### PR TITLE
Fixes Issue #4024, unable to open private tab using keyboard shortcut from a PDF tab

### DIFF
--- a/web/pdf_print_service.js
+++ b/web/pdf_print_service.js
@@ -272,9 +272,9 @@ var hasAttachEvent = !!document.attachEvent;
 
 window.addEventListener('keydown', function(event) {
   // Intercept Cmd/Ctrl + P in all browsers.
-  // Also intercept Cmd/Ctrl + Shift + P in Chrome and Opera
   if (event.keyCode === /* P= */ 80 && (event.ctrlKey || event.metaKey) &&
-      !event.altKey && (!event.shiftKey || window.chrome || window.opera)) {
+      !event.altKey && !event.shiftKey) {
+
     window.print();
     if (hasAttachEvent) {
       // Only attachEvent can cancel Ctrl + P dialog in IE <=10


### PR DESCRIPTION
@bsclifton 
Fix [brave/browser-laptop#4024](https://github.com/brave/browser-laptop/issues/4024)

Test Plan:

 0. Build  and load the pdf extension
1. Run webpack: npm run watch
2. Run Brave: npm run start
3. Open any pdf: http://unec.edu.az/application/uploads/2014/12/pdf-sample.pdf
4. To open a new private tab: Press Ctrl + Shift + P
5. Result: Launches a new private tab.

Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


